### PR TITLE
Add image header to cards

### DIFF
--- a/client/src/Validation/PasswordResetValidation.tsx
+++ b/client/src/Validation/PasswordResetValidation.tsx
@@ -6,7 +6,7 @@ export const validationSchema = yup.object({
         .required('Please enter your password')
         .matches(
             /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/,
-            "Must contain eight characters, one uppercase, one lowercase, one number and one special character"
+            "Must contain at least eight characters, one uppercase, one lowercase, one number and one special character"
         ),
     confirmPassword: yup.string().oneOf([(yup.ref('password'))], "Passwords must match").required("Please confirm your password")
 })

--- a/client/src/Validation/SignInValidation.tsx
+++ b/client/src/Validation/SignInValidation.tsx
@@ -8,6 +8,6 @@ export const validationSchema = yup.object({
         .required('Please enter your password')
         .matches(
             /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/,
-            "Must contain eight characters, one uppercase, one lowercase, one number and one special character"
+            "Must contain at least eight characters, one uppercase, one lowercase, one number and one special character"
         )
 })

--- a/client/src/Validation/SignUpValidation.ts
+++ b/client/src/Validation/SignUpValidation.ts
@@ -9,6 +9,6 @@ export const validationSchema = yup.object({
         .required('Please enter your password')
         .matches(
             /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/,
-            "Must contain eight characters, one uppercase, one lowercase, one number and one special character"
+            "Must contain at least eight characters, one uppercase, one lowercase, one number and one special character"
         )
 })

--- a/client/src/components/ImageCard.tsx
+++ b/client/src/components/ImageCard.tsx
@@ -8,9 +8,10 @@ import {setFeedImages, setImages} from "../slices/userSlice";
 import {useDispatch,} from "react-redux";
 import {decodeToken} from "react-jwt";
 import { base_be_url } from "../util/constants";
-import Button from "@mui/material/Button";
 import {useNavigate} from "react-router-dom";
 import constants from "../statics/constants";
+import ImageHeader from "./ImageHeader";
+
 
 export default function ImageCard({ imageData, isFeed }: { imageData: ImageData, isFeed: boolean }) {
     const dispatch = useDispatch();
@@ -64,29 +65,25 @@ export default function ImageCard({ imageData, isFeed }: { imageData: ImageData,
 
     return (
         <div className="card w-auto bg-base-100 shadow-xl">
-            {isFeed && <Button onClick={() => navigateToUser(imageData.username)}
-                               style={{textTransform: 'none', fontSize: "20px"}}>{imageData.username}</Button>}
+            <ImageHeader username={imageData.username}></ImageHeader>
             <figure>
                 <img 
                     src={imageData.url}  
                     alt={imageData.id} 
                     className="object-cover object-top aspect-square" />
             </figure>
-            <Box sx={{paddingTop: 5, paddingLeft: 5, display: 'flex',}}>
+            <Box sx={{paddingTop: 1, paddingLeft: 1, display: 'flex',}}>
 
                 {imageData.likes.includes(loggedInUserId) ? <FavoriteIcon fontSize="large" style={{ color: 'rgb(255,0,0)' }}
                                                                           onClick={() =>handleLike(imageData.id,loggedInUserId)}/>
                     : <FavoriteBorderIcon fontSize="large" sx={{ "&:hover": { color: "gray"} }}
                                           onClick={() => handleLike(imageData.id,loggedInUserId)}/>}
             </Box>
-            <Typography align="left" sx={{paddingTop: 1, paddingLeft: 6}}>{imageData.likes.length}
-                {imageData.likes.length === 1 ? " like" : " likes"} </Typography>
-            <div className="card-body">
-                <p>{imageData.description}</p>
-                <Typography sx={{ fontSize: 14 }} color="text.secondary">
-                    {formattedDate}
-                </Typography>
-
+            <Typography align="left" sx={{paddingTop: 1, paddingLeft: 3}}>{imageData.likes.length}
+                {imageData.likes.length === 1 ? " like" : " likes"}
+            </Typography>
+            <div className="flex pl-6 pb-2 text-xs text-[#666666]">
+                {formattedDate}
             </div>
 
         </div>

--- a/client/src/components/ImageHeader.tsx
+++ b/client/src/components/ImageHeader.tsx
@@ -1,4 +1,4 @@
-import {Button} from "@mui/material"
+import {Button, Typography} from "@mui/material"
 import {useNavigate} from "react-router-dom";
 
 const ImageHeader = ({username}: {username: String}) => {
@@ -15,7 +15,10 @@ const ImageHeader = ({username}: {username: String}) => {
             </label>
             <Button onClick={() => navigateToUser(username)}
                     style={{textTransform: 'none', color: "black",backgroundColor: 'transparent'}}>
-                {username}
+                <Typography style={{ fontSize: "0.8rem" }} fontWeight="bold" >
+                    {username}
+                </Typography>
+
             </Button>
         </div>
     )

--- a/client/src/components/ImageHeader.tsx
+++ b/client/src/components/ImageHeader.tsx
@@ -1,0 +1,24 @@
+import {Button} from "@mui/material"
+import {useNavigate} from "react-router-dom";
+
+const ImageHeader = ({username}: {username: String}) => {
+    const navigate = useNavigate();
+    const navigateToUser = (username: String) => {
+        navigate(`/${username}`)
+    }
+    return (
+        <div className="flex">
+            <label className="btn btn-ghost btn-circle avatar">
+                <div className="w-10 rounded-full">
+                    <img onClick={() => navigateToUser(username)} alt="profile-pic" src="https://api.lorem.space/image/face?hash=33791" />
+                </div>
+            </label>
+            <Button onClick={() => navigateToUser(username)}
+                    style={{textTransform: 'none', color: "black",backgroundColor: 'transparent'}}>
+                {username}
+            </Button>
+        </div>
+    )
+}
+
+export default ImageHeader

--- a/client/src/components/Popup.tsx
+++ b/client/src/components/Popup.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {useNavigate} from "react-router-dom";
-import {Stack} from "@mui/material";
+import {Stack, Typography} from "@mui/material";
 import Button from "@mui/material/Button";
 
 export default function Popup({onClose, visible, target, userData}: any) {
@@ -38,7 +38,14 @@ export default function Popup({onClose, visible, target, userData}: any) {
                 (<Stack>{
                     usernameList.map((element: any) =>
                     {
-                        return <Button onClick={()=>navigateToUser(element)} style={{textTransform: 'none'}}>{element}</Button>
+                        return <Button style={{textTransform: 'none', color: "black",}}
+                                       onClick={()=>navigateToUser(element)} >
+                            <Typography style={{ fontSize: "0.8rem" }} fontWeight="bold" >
+                                {element}
+                            </Typography>
+                            <br/>
+                        </Button>
+
                     })
                 }</Stack>) : <div>No {target}</div>
         }

--- a/client/src/components/SuggestedUserCard.tsx
+++ b/client/src/components/SuggestedUserCard.tsx
@@ -9,19 +9,20 @@ const SuggestedUserCard = ({suggestedUserData}: { suggestedUserData: any, }) => 
     }
 
     return (
-        <div >
-            <Card>
-                    <label tabIndex={0} className="btn btn-ghost btn-circle avatar">
+            <Card style={{cursor: 'pointer'}} onClick={() => navigateToUser(suggestedUserData.username)} sx={{
+                width: 250
+            }}>
+                <div className="flex">
+                    <label className="btn btn-ghost btn-circle avatar">
                         <div className="w-10 rounded-full">
-                            <img alt="profile-pic" src="https://api.lorem.space/image/face?hash=33791" />
+                            <img onClick={() => navigateToUser(suggestedUserData.username)} alt="profile-pic" src="https://api.lorem.space/image/face?hash=33791" />
                         </div>
                     </label>
-                        <Button onClick={() => navigateToUser(suggestedUserData.username)} style={{textTransform: 'none',}}>
+                        <Button onClick={() => navigateToUser(suggestedUserData.username)} style={{textTransform: 'none', color: "black",backgroundColor: 'transparent'}}>
                             {suggestedUserData.username}
                         </Button>
+                </div>
             </Card>
-        </div>
-
     )
 }
 

--- a/client/src/components/SuggestedUserCard.tsx
+++ b/client/src/components/SuggestedUserCard.tsx
@@ -1,6 +1,6 @@
 import Button from "@mui/material/Button";
 import {useNavigate} from "react-router-dom";
-import {Card} from "@mui/material";
+import {Card, Typography} from "@mui/material";
 
 const SuggestedUserCard = ({suggestedUserData}: { suggestedUserData: any, }) => {
     const navigate = useNavigate();
@@ -19,7 +19,9 @@ const SuggestedUserCard = ({suggestedUserData}: { suggestedUserData: any, }) => 
                         </div>
                     </label>
                         <Button onClick={() => navigateToUser(suggestedUserData.username)} style={{textTransform: 'none', color: "black",backgroundColor: 'transparent'}}>
-                            {suggestedUserData.username}
+                            <Typography style={{ fontSize: "0.8rem" }} fontWeight="bold" >
+                                {suggestedUserData.username}
+                            </Typography>
                         </Button>
                 </div>
             </Card>

--- a/client/src/pages/SignIn.tsx
+++ b/client/src/pages/SignIn.tsx
@@ -26,6 +26,7 @@ import { useDispatch } from "react-redux";
 import {decodeToken} from "react-jwt";
 import { base_be_url } from "../util/constants";
 import axios from "axios";
+import CircularProgress from "@mui/material/CircularProgress";
 
 function Copyright(props: any) {
     return (
@@ -43,6 +44,7 @@ const theme = createTheme();
 export default function SignInSide() {
 
     const [invalidLogin, setInvalidLogin] = useState(false);
+    const [isSigningIn, setIsSigningIn] = useState(false);
     const dispatch = useDispatch();
 
     const formik: any = useFormik({
@@ -76,6 +78,7 @@ export default function SignInSide() {
     const tryLogin = async (usernameOrEmail: string, password: string) => {
         let response: any;
         try {
+            setIsSigningIn(true)
             response = await axios.post(
                 `${base_be_url}/api/users/login`, {
                     usernameOrEmail: usernameOrEmail,
@@ -92,6 +95,8 @@ export default function SignInSide() {
                 })
                 throw new Error(err.response.data.message)
             }
+        } finally {
+            setIsSigningIn(false)
         }
         const data = response.data
         localStorage.setItem("authToken", data.token);
@@ -169,6 +174,7 @@ export default function SignInSide() {
                             >
                                 Sign In
                             </Button>
+                            {isSigningIn && <CircularProgress />}
                             <Grid container>
                                 <Grid item xs>
                                     <Link href="/forgot-password" variant="body2">

--- a/client/src/pages/Signup.tsx
+++ b/client/src/pages/Signup.tsx
@@ -22,6 +22,7 @@ import {Alert} from "@mui/material";
 import TEXT from "../statics/text";
 import { base_be_url } from '../util/constants';
 import axios from "axios";
+import CircularProgress from "@mui/material/CircularProgress";
 
 function Copyright(props: any) {
     return (
@@ -39,6 +40,7 @@ const theme = createTheme();
 export default function SignUp() {
 
     const [invalidSignup, setInvalidSignup] = useState(false);
+    const [isSigningUp, setIsSigningUp] = useState(false);
 
     const navigate = useNavigate();
 
@@ -72,6 +74,7 @@ export default function SignUp() {
         let response: any;
 
         try {
+            setIsSigningUp(true)
             response = await axios.post(
                 `${base_be_url}/api/users/register`, {
                     username: username,
@@ -89,6 +92,8 @@ export default function SignUp() {
                 })
                 throw new Error(err.response.data.message)
             }
+        } finally {
+            setIsSigningUp(false)
         }
 
         const data = response.data
@@ -168,6 +173,7 @@ export default function SignUp() {
                         >
                             Sign Up
                         </Button>
+                        {isSigningUp && <CircularProgress />}
                         <Grid container justifyContent="flex-end">
                             <Grid item>
                                 <Link href="/signIn" variant="body2">

--- a/client/src/pages/UserPage.tsx
+++ b/client/src/pages/UserPage.tsx
@@ -24,6 +24,7 @@ import {base_be_url} from "../util/constants";
 import Typography from "@mui/material/Typography";
 import SuggestedUserCard from "../components/SuggestedUserCard";
 
+
 const UserPage = () => {
     const { username } = useParams();
     const [suggestedUsersToFollow, setSuggestedUsersToFollow] = useState([]);
@@ -180,7 +181,6 @@ const UserPage = () => {
                         </div>
                     </div>
                     { loggedInUserId === userData.userId && <ImageUpload setIsUploadingImage={setIsUploadingImage}/>}
-
                 </div>
                 </div>
                 {isUploadingImage && <div className="flex justify-center items-center">

--- a/client/src/util/functions.ts
+++ b/client/src/util/functions.ts
@@ -57,3 +57,5 @@ export const uploadImage = async (formData: any, token: string) => {
     }
   }
 };
+
+


### PR DESCRIPTION
- Added image header to cards on feed and profile.
-  Set card for user suggestion to appropriately accommodate max username length. Users can now click any of the part of the box and be directed to the user's profile
-  User can click on name or circular profile picture on a post to be navigated to user's profile
- Added loading spinner for login page
- General UI improvements

Before:
![image](https://user-images.githubusercontent.com/83941101/183241237-b0b2d1a3-6581-4a19-a6a0-d6b66116b12a.png)
![image](https://user-images.githubusercontent.com/83941101/183241279-5edd4bba-a17e-4564-99ce-f0bd0959fd3b.png)



After:
![image](https://user-images.githubusercontent.com/83941101/183242039-d97d889c-057e-413f-bcff-e379b7d4d7d6.png)
![image](https://user-images.githubusercontent.com/83941101/183242058-711f928d-7638-4f6a-bd4c-7ebc634532c4.png)



