### PR TITLE
Finish endpoint for random sampling of suggested users and updated fi…

### DIFF
--- a/client/src/components/SuggestedUserCard.tsx
+++ b/client/src/components/SuggestedUserCard.tsx
@@ -8,12 +8,14 @@ const SuggestedUserCard = ({suggestedUserData}: { suggestedUserData: any, }) => 
         navigate(`/${username}`)
     }
 
+    const profilePictureURL = suggestedUserData.profilePicture;
+
     return (
         <div >
             <Card>
                     <label tabIndex={0} className="btn btn-ghost btn-circle avatar">
                         <div className="w-10 rounded-full">
-                            <img alt="profile-pic" src="https://api.lorem.space/image/face?hash=33791" />
+                            <img alt="profile-pic" src="https://api.lorem.space/image/face?hash=33791"/>
                         </div>
                     </label>
                         <Button onClick={() => navigateToUser(suggestedUserData.username)} style={{textTransform: 'none',}}>

--- a/client/src/pages/UserPage.tsx
+++ b/client/src/pages/UserPage.tsx
@@ -53,7 +53,6 @@ const UserPage = () => {
         }
 
         async function getUserData() {
-
             let response;
             try {
                 if (username) {
@@ -76,14 +75,13 @@ const UserPage = () => {
                 const res = await axios.get(
                     `${base_be_url}/api/images/following/${loggedInUserId}`
                 )
-                dispatch(setFeedImages(res.data.data));
-
-                const result = await axios.get(
-                    `${base_be_url}/api/users?limit=40`
+                dispatch(setFeedImages(res.data.images));
+                const loggedInUserFollowing = res.data.following;
+                const randomUsers = await axios.get(
+                    `${base_be_url}/api/users/random?limit=16`
                 )
-
-                const suggestedFollowing = result.data.data.filter( (user: any) => {
-                    return user.username !== loggedInUsername && user.images.length !== 0;
+                const suggestedFollowing = randomUsers.data.data.filter( (user: any) => {
+                    return user.username !== loggedInUsername && !loggedInUserFollowing.includes(user._id);
                 })
                 setSuggestedUsersToFollow(suggestedFollowing);
             } catch (err) {

--- a/server/controllers/imageController.ts
+++ b/server/controllers/imageController.ts
@@ -227,6 +227,7 @@ export const getAllFollowingImages = async (req: Request, res: Response) => {
 
   return res.status(200).json({
     message: "Successfully retrieved all following images",
-    data: sortedImages
+    images: sortedImages,
+    following: followingIdArr,
   });
 }

--- a/server/controllers/userControllers.ts
+++ b/server/controllers/userControllers.ts
@@ -196,6 +196,53 @@ export const followUser = async (req: Request, res: Response) => {
 }
 
 /**
+ * @param Expected request body: none,
+ * request query parameters (optional): limit
+ * * @param Responds Responds with a success message, along with a random number of user's data or an error
+ */
+
+export const getRandomUsers = async (req: Request, res: Response) => {
+    const limit = Number(req.query.limit);
+    let randomUsers;
+    try {
+        randomUsers = await User.aggregate([{$sample: {size: limit}},
+            {$project: {username: 1, profilePicture: 1, _id: 1, images: 1}}]);
+    } catch (err) {
+        return res.status(500).json({
+            message: "Error while fetching random users from MongoDb",
+            error: err,
+        });
+    }
+    return res.status(200).json({
+        message: `Successfully got ${limit} random users`,
+        data: randomUsers,
+    });
+}
+
+/**
+ * @param Expected request body: none, request url parameters: id
+ * * @param Responds Responds with a success message, along with all the following of user with userid: id or an error
+ */
+export const getAllFollowing = async (req: Request, res: Response) => {
+    const {id} = req.params;
+    let followingArr;
+    try {
+        followingArr = await User.findOne({
+            _id: id
+        }).select('followings -_id')
+    } catch (err) {
+        return res.status(500).json({
+            message: "Error getting followingArr from Mongodb",
+            error: err,
+        });
+    }
+    return res.status(200).json({
+        message: `Successfully got following`,
+        data: followingArr,
+    });
+}
+
+/**
  * @param Expected request body: unfollowingUsername: the username of the user who is currently logged in and unfollowing
  * a user, unfollowedUsername: the username of the user being unfollowed
  * request url parameters: unfollowingUserId: the id of the user who is following a user, unfollowedUserId: the
@@ -283,3 +330,4 @@ export const editUser = (req:Request, res: Response) => {
     }
         
 }
+

--- a/server/router.ts
+++ b/server/router.ts
@@ -1,6 +1,14 @@
 import express from "express";
 import {resetPassword, forgotPassword, loginUser, registerUser} from "./controllers/authControllers";
-import {getUser, getAllUsers, editUser, followUser, unfollowUser} from "./controllers/userControllers";
+import {
+    getUser,
+    getAllUsers,
+    editUser,
+    followUser,
+    unfollowUser,
+    getRandomUsers,
+    getAllFollowing
+} from "./controllers/userControllers";
 import {getAllFollowingImages, likePost, unlikePost, uploadImage} from "./controllers/imageController";
 
 import { protect } from "./middleware/auth";
@@ -30,6 +38,8 @@ router.get("/api/images/following/:userId", getAllFollowingImages);
  */
 
 router.get("/api/users", getAllUsers);
+router.get("/api/users/random", getRandomUsers)
+router.get("/api/users/:id/following", getAllFollowing)
 router.get("/api/users/:id", getUser);
 router.put("/api/users/:id", editUser);
 


### PR DESCRIPTION
- Implemented 2 new endpoints, one for fetching all the following of a specified user and one to randomly sample users from the database
- The latter is used to suggest followings to a user (before I was just returning the first x users from the database, but the suggestions were always the same based off the order of the entries in MongoDB)
- Fixed filtering logic on following suggestions. Now the suggested followings are appropriately filtered to remove users that the currentUser already follows from the list. Before the filtering was just relying on the fact that we only displayed suggested users to those that had 0 following.